### PR TITLE
auto-apply authentication from client config

### DIFF
--- a/kubernetes-client/kubernetes-client.cabal
+++ b/kubernetes-client/kubernetes-client.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           kubernetes-client
-version:        0.4.3.1
+version:        0.4.3.2
 synopsis:       Client library for Kubernetes
 description:    Client library for interacting with a Kubernetes cluster.
                 .
@@ -66,7 +66,7 @@ library
     , http-client-tls >=0.3
     , jose-jwt >=0.8
     , jsonpath >=0.1 && <0.3
-    , kubernetes-client-core ==0.4.3.0
+    , kubernetes-client-core ==0.4.3.2
     , microlens >=0.4
     , mtl >=2.2
     , oidc-client >=0.4
@@ -114,7 +114,7 @@ test-suite example
     , jose-jwt >=0.8
     , jsonpath >=0.1 && <0.3
     , kubernetes-client
-    , kubernetes-client-core ==0.4.3.0
+    , kubernetes-client-core ==0.4.3.2
     , microlens >=0.4
     , mtl >=2.2
     , oidc-client >=0.4
@@ -170,7 +170,7 @@ test-suite spec
     , jose-jwt >=0.8
     , jsonpath >=0.1 && <0.3
     , kubernetes-client
-    , kubernetes-client-core ==0.4.3.0
+    , kubernetes-client-core ==0.4.3.2
     , microlens >=0.4
     , mtl >=2.2
     , oidc-client >=0.4

--- a/kubernetes-client/package.yaml
+++ b/kubernetes-client/package.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-client
-version: 0.4.3.1
+version: 0.4.3.2
 description: |
   Client library for interacting with a Kubernetes cluster.
 
@@ -50,7 +50,7 @@ dependencies:
   - http-client >=0.5 && <0.8
   - http-client-tls >=0.3
   - jose-jwt >=0.8
-  - kubernetes-client-core ==0.4.3.0
+  - kubernetes-client-core ==0.4.3.2
   - microlens >=0.4
   - mtl >=2.2
   - oidc-client >=0.4

--- a/kubernetes-client/src/Kubernetes/Client/Auth/Basic.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/Basic.hs
@@ -12,7 +12,8 @@ import           Kubernetes.Client.KubeConfig
 
 import qualified Data.Text.Encoding            as T
 import qualified Lens.Micro                    as L
-
+import qualified Data.Proxy                    as P
+import qualified Data.Data                     as P (typeRep)
 
 data BasicAuth = BasicAuth { basicAuthUsername :: Text
                            , basicAuthPassword :: Text
@@ -41,5 +42,7 @@ setBasicAuth
   -> KubernetesClientConfig
   -> KubernetesClientConfig
 setBasicAuth u p kcfg = kcfg
-  { configAuthMethods = [AnyAuthMethod (BasicAuth u p)]
+  { configAuthMethods = [AnyAuthMethod typeRep (BasicAuth u p)]
   }
+  where
+    typeRep = P.typeRep (P.Proxy :: P.Proxy BasicAuth)

--- a/kubernetes-client/src/Kubernetes/Client/Auth/Exec.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/Exec.hs
@@ -35,6 +35,8 @@ import qualified Data.HashMap.Strict as HashMap
 import Data.Text (Text, unpack)
 import Data.Time (UTCTime, getCurrentTime, addUTCTime)
 import Data.Typeable (typeOf)
+import qualified Data.Proxy as P
+import qualified Data.Data as P (typeRep)
 import GHC.Generics (Generic)
 import Kubernetes.Client.Auth.Internal.Types (DetectAuth)
 import Kubernetes.Client.KubeConfig (AuthInfo (..), ExecConfig (..), ExecEnvVar (..))
@@ -120,9 +122,11 @@ execAuth mcache refreshBefore decodeToken AuthInfo {exec} (tlsParams, cfg) = do
     pure
       ( tlsParams
       , cfg
-          { configAuthMethods = [AnyAuthMethod (Exec config decodeToken refreshBefore mcache)]
+          { configAuthMethods = [AnyAuthMethod typeRep (Exec config decodeToken refreshBefore mcache)]
           }
       )
+  where
+    typeRep = P.typeRep (P.Proxy :: P.Proxy Exec)
 
 --------------------------------------------------------------------------------
 -- Cache

--- a/kubernetes-client/src/Kubernetes/Client/Auth/Token.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/Token.hs
@@ -10,6 +10,8 @@ import           Kubernetes.OpenAPI.Core        ( AnyAuthMethod(..)
 import           Kubernetes.OpenAPI.Model       ( AuthApiKeyBearerToken(..) )
 
 import qualified Data.Text                     as T
+import qualified Data.Proxy                    as P
+import qualified Data.Data                     as P (typeRep)
 
 -- |Detects if token is specified in AuthConfig, if it is configures 'KubernetesClientConfig' with 'AuthApiKeyBearerToken'
 tokenAuth :: DetectAuth
@@ -23,5 +25,7 @@ setTokenAuth
   -> KubernetesClientConfig
   -> KubernetesClientConfig
 setTokenAuth t kcfg = kcfg
-  { configAuthMethods = [AnyAuthMethod (AuthApiKeyBearerToken $ "Bearer " <> t)]
+  { configAuthMethods = [AnyAuthMethod typeRep (AuthApiKeyBearerToken $ "Bearer " <> t)]
   }
+  where
+    typeRep = P.typeRep (P.Proxy :: P.Proxy AuthApiKeyBearerToken)

--- a/kubernetes-client/src/Kubernetes/Client/Auth/TokenFile.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/TokenFile.hs
@@ -14,6 +14,8 @@ import           Kubernetes.Client.KubeConfig
 import qualified Data.Text                     as T
 import qualified Data.Text.IO                  as T
 import qualified Lens.Micro                    as L
+import qualified Data.Proxy                    as P
+import qualified Data.Data                     as P (typeRep)
 
 data TokenFileAuth = TokenFileAuth { token :: TVar(Maybe Text)
                                    , expiry :: TVar(Maybe UTCTime)
@@ -46,9 +48,12 @@ setTokenFileAuth f kcfg = atomically $ do
   return kcfg
     { configAuthMethods =
       [ AnyAuthMethod
+          typeRep
           (TokenFileAuth { token = t, expiry = e, file = f, period = 60 })
       ]
     }
+  where
+    typeRep = P.typeRep (P.Proxy :: P.Proxy TokenFileAuth)
 
 getToken :: TokenFileAuth -> IO Text
 getToken auth = getCurrentToken auth >>= maybe (reloadToken auth) return

--- a/kubernetes/kubernetes-client-core.cabal
+++ b/kubernetes/kubernetes-client-core.cabal
@@ -1,5 +1,5 @@
 name:           kubernetes-client-core
-version:        0.4.3.0
+version:        0.4.3.2
 synopsis:       Auto-generated kubernetes-client-core API Client
 description:    .
                 Client library for calling the Kubernetes API based on http-client.

--- a/kubernetes/lib/Kubernetes/OpenAPI/Core.hs
+++ b/kubernetes/lib/Kubernetes/OpenAPI/Core.hs
@@ -115,9 +115,9 @@ newConfig = do
         }
 
 -- | updates config use AuthMethod on matching requests
-addAuthMethod :: AuthMethod auth => KubernetesClientConfig -> auth -> KubernetesClientConfig
+addAuthMethod :: forall auth. (AuthMethod auth) => KubernetesClientConfig -> auth -> KubernetesClientConfig
 addAuthMethod config@KubernetesClientConfig {configAuthMethods = as} a =
-  config { configAuthMethods = AnyAuthMethod a : as}
+  config { configAuthMethods = AnyAuthMethod (P.typeRep (P.Proxy :: P.Proxy auth)) a : as}
 
 -- | updates the config to use stdout logging
 withStdoutLogging :: KubernetesClientConfig -> IO KubernetesClientConfig
@@ -407,9 +407,9 @@ class P.Typeable a =>
     -> IO (KubernetesRequest req contentType res accept)
 
 -- | An existential wrapper for any AuthMethod
-data AnyAuthMethod = forall a. AuthMethod a => AnyAuthMethod a deriving (P.Typeable)
+data AnyAuthMethod = forall a. AuthMethod a => AnyAuthMethod P.TypeRep a deriving (P.Typeable)
 
-instance AuthMethod AnyAuthMethod where applyAuthMethod config (AnyAuthMethod a) req = applyAuthMethod config a req
+instance AuthMethod AnyAuthMethod where applyAuthMethod config (AnyAuthMethod _ a) req = applyAuthMethod config a req
 
 -- | indicates exceptions related to AuthMethods
 data AuthMethodException = AuthMethodException String deriving (P.Show, P.Typeable)
@@ -421,10 +421,12 @@ _applyAuthMethods
   :: KubernetesRequest req contentType res accept
   -> KubernetesClientConfig
   -> IO (KubernetesRequest req contentType res accept)
-_applyAuthMethods req config@(KubernetesClientConfig {configAuthMethods = as}) =
-  foldlM go req as
+_applyAuthMethods req config@(KubernetesClientConfig {configAuthMethods = as}) = do
+  let reqWithAuthTypes = P.foldr addAuthTypeToReq req as
+  foldlM go reqWithAuthTypes as
   where
-    go r (AnyAuthMethod a) = applyAuthMethod config a r
+    go r (AnyAuthMethod _ a) = applyAuthMethod config a r
+    addAuthTypeToReq (AnyAuthMethod typeRep _) r = r & L.over rAuthTypesL (typeRep :)
 
 -- * Utils
 


### PR DESCRIPTION
This modifies the Kubernetes client to automatically apply all authentication methods available in the client config when dispatching requests.

Since we know which authentication methods are available when constructing the client config, we can leverage that information instead of having explicit `_hasAuthType` calls in the request construction. This prevents us from adding auth types for clients that don't actually have those auth types configured in their respective client config.