### PR TITLE
auto-apply authentication from client config

### DIFF
--- a/kubernetes-1.20/lib/Kubernetes/OpenAPI/Core.hs
+++ b/kubernetes-1.20/lib/Kubernetes/OpenAPI/Core.hs
@@ -116,9 +116,9 @@ newConfig = do
         }
 
 -- | updates config use AuthMethod on matching requests
-addAuthMethod :: AuthMethod auth => KubernetesClientConfig -> auth -> KubernetesClientConfig
+addAuthMethod :: forall auth. (AuthMethod auth) => KubernetesClientConfig -> auth -> KubernetesClientConfig
 addAuthMethod config@KubernetesClientConfig {configAuthMethods = as} a =
-  config { configAuthMethods = AnyAuthMethod a : as}
+  config { configAuthMethods = AnyAuthMethod (P.typeRep (P.Proxy :: P.Proxy auth)) a : as}
 
 -- | updates the config to use stdout logging
 withStdoutLogging :: KubernetesClientConfig -> IO KubernetesClientConfig
@@ -414,9 +414,9 @@ class P.Typeable a =>
     -> IO (KubernetesRequest req contentType res accept)
 
 -- | An existential wrapper for any AuthMethod
-data AnyAuthMethod = forall a. AuthMethod a => AnyAuthMethod a deriving (P.Typeable)
+data AnyAuthMethod = forall a. AuthMethod a => AnyAuthMethod P.TypeRep a deriving (P.Typeable)
 
-instance AuthMethod AnyAuthMethod where applyAuthMethod config (AnyAuthMethod a) req = applyAuthMethod config a req
+instance AuthMethod AnyAuthMethod where applyAuthMethod config (AnyAuthMethod _ a) req = applyAuthMethod config a req
 
 -- | indicates exceptions related to AuthMethods
 data AuthMethodException = AuthMethodException String deriving (P.Show, P.Typeable)
@@ -428,10 +428,12 @@ _applyAuthMethods
   :: KubernetesRequest req contentType res accept
   -> KubernetesClientConfig
   -> IO (KubernetesRequest req contentType res accept)
-_applyAuthMethods req config@(KubernetesClientConfig {configAuthMethods = as}) =
-  foldlM go req as
+_applyAuthMethods req config@(KubernetesClientConfig {configAuthMethods = as}) = do
+  let reqWithAuthTypes = P.foldr addAuthTypeToReq req as
+  foldlM go reqWithAuthTypes as
   where
-    go r (AnyAuthMethod a) = applyAuthMethod config a r
+    go r (AnyAuthMethod _ a) = applyAuthMethod config a r
+    addAuthTypeToReq (AnyAuthMethod typeRep _) r = r & L.over rAuthTypesL (typeRep :)
 
 -- * Utils
 

--- a/kubernetes-client/src/Kubernetes/Client/Auth/Basic.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/Basic.hs
@@ -16,6 +16,8 @@ import Data.Monoid                              ((<>))
 
 import qualified Data.Text.Encoding            as T
 import qualified Lens.Micro                    as L
+import qualified Data.Proxy                    as P
+import qualified Data.Data                     as P (typeRep)
 
 data BasicAuth = BasicAuth { basicAuthUsername :: Text
                            , basicAuthPassword :: Text
@@ -44,5 +46,7 @@ setBasicAuth
   -> KubernetesClientConfig
   -> KubernetesClientConfig
 setBasicAuth u p kcfg = kcfg
-  { configAuthMethods = [AnyAuthMethod (BasicAuth u p)]
+  { configAuthMethods = [AnyAuthMethod typeRep (BasicAuth u p)]
   }
+  where
+    typeRep = P.typeRep (P.Proxy :: P.Proxy BasicAuth)

--- a/kubernetes-client/src/Kubernetes/Client/Auth/Exec.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/Exec.hs
@@ -35,6 +35,8 @@ import qualified Data.HashMap.Strict as HashMap
 import Data.Text (Text, unpack)
 import Data.Time (UTCTime, getCurrentTime, addUTCTime)
 import Data.Typeable (typeOf)
+import qualified Data.Proxy as P
+import qualified Data.Data as P (typeRep)
 import GHC.Generics (Generic)
 import Kubernetes.Client.Auth.Internal.Types (DetectAuth)
 import Kubernetes.Client.KubeConfig (AuthInfo (..), ExecConfig (..), ExecEnvVar (..))
@@ -120,9 +122,11 @@ execAuth mcache refreshBefore decodeToken AuthInfo {exec} (tlsParams, cfg) = do
     pure
       ( tlsParams
       , cfg
-          { configAuthMethods = [AnyAuthMethod (Exec config decodeToken refreshBefore mcache)]
+          { configAuthMethods = [AnyAuthMethod typeRep (Exec config decodeToken refreshBefore mcache)]
           }
       )
+  where
+    typeRep = P.typeRep (P.Proxy :: P.Proxy Exec)
 
 --------------------------------------------------------------------------------
 -- Cache

--- a/kubernetes-client/src/Kubernetes/Client/Auth/Token.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/Token.hs
@@ -10,6 +10,8 @@ import           Kubernetes.OpenAPI.Core        ( AnyAuthMethod(..)
 import           Kubernetes.OpenAPI.Model       ( AuthApiKeyBearerToken(..) )
 
 import qualified Data.Text                     as T
+import qualified Data.Proxy                    as P
+import qualified Data.Data                     as P (typeRep)
 
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Monoid                    ( (<>) )
@@ -28,5 +30,7 @@ setTokenAuth
   -> KubernetesClientConfig
   -> KubernetesClientConfig
 setTokenAuth t kcfg = kcfg
-  { configAuthMethods = [AnyAuthMethod (AuthApiKeyBearerToken $ "Bearer " <> t)]
+  { configAuthMethods = [AnyAuthMethod typeRep (AuthApiKeyBearerToken $ "Bearer " <> t)]
   }
+  where
+    typeRep = P.typeRep (P.Proxy :: P.Proxy AuthApiKeyBearerToken)

--- a/kubernetes-client/src/Kubernetes/Client/Auth/TokenFile.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/TokenFile.hs
@@ -13,6 +13,8 @@ import           Kubernetes.Client.Auth.Internal.Types
 import           Kubernetes.Client.KubeConfig hiding ( token )
 import           Kubernetes.OpenAPI.Core
 import qualified Lens.Micro                    as L
+import qualified Data.Proxy                    as P
+import qualified Data.Data                     as P (typeRep)
 
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Monoid                    ( (<>) )
@@ -49,9 +51,13 @@ setTokenFileAuth f kcfg = atomically $ do
   e <- newTVar (Nothing :: Maybe UTCTime)
   return kcfg
     { configAuthMethods =
-      [ AnyAuthMethod (TokenFileAuth { token = t, expiry = e, file = f, period = 60 })
+      [ AnyAuthMethod
+          typeRep
+          (TokenFileAuth { token = t, expiry = e, file = f, period = 60 })
       ]
     }
+  where
+    typeRep = P.typeRep (P.Proxy :: P.Proxy TokenFileAuth)
 
 getToken :: TokenFileAuth -> IO Text
 getToken auth = getCurrentToken auth >>= maybe (reloadToken auth) return


### PR DESCRIPTION
This modifies the Kubernetes client to automatically apply all authentication methods available in the client config when dispatching requests.

Since we know which authentication methods are available when constructing the client config, we can leverage that information instead of having explicit `_hasAuthType` calls in the request construction. This prevents us from adding auth types for clients that don't actually have those auth types configured in their respective client config.